### PR TITLE
Fix Flame icon asset paths

### DIFF
--- a/lib/game/energy_game.dart
+++ b/lib/game/energy_game.dart
@@ -51,19 +51,17 @@ class EnergyGame extends FlameGame {
   Future<void> onLoad() async {
     await _loadProgress();
 
-    await images.loadAll([
-      'images/icons/icon_solar.png',
-      'images/icons/icon_wind.png',
-      'images/icons/icon_efficiency.png',
-      'images/icons/icon_sanitation.png',
-    ]);
+    const iconPaths = {
+      Building.solar: 'icons/icon_solar.png',
+      Building.eolica: 'icons/icon_wind.png',
+      Building.eficiencia: 'icons/icon_efficiency.png',
+      Building.saneamento: 'icons/icon_sanitation.png',
+    };
+
+    await images.loadAll(iconPaths.values);
     sprites = {
-      Building.solar: Sprite(images.fromCache('images/icons/icon_solar.png')),
-      Building.eolica: Sprite(images.fromCache('images/icons/icon_wind.png')),
-      Building.eficiencia:
-          Sprite(images.fromCache('images/icons/icon_efficiency.png')),
-      Building.saneamento:
-          Sprite(images.fromCache('images/icons/icon_sanitation.png')),
+      for (final entry in iconPaths.entries)
+        entry.key: Sprite(images.fromCache(entry.value)),
     };
 
     await Flame.device.fullScreen();

--- a/lib/game/energy_game.dart
+++ b/lib/game/energy_game.dart
@@ -58,7 +58,7 @@ class EnergyGame extends FlameGame {
       Building.saneamento: 'icons/icon_sanitation.png',
     };
 
-    await images.loadAll(iconPaths.values);
+    await images.loadAll(iconPaths.values.toList());
     sprites = {
       for (final entry in iconPaths.entries)
         entry.key: Sprite(images.fromCache(entry.value)),

--- a/lib/ui/hud.dart
+++ b/lib/ui/hud.dart
@@ -164,13 +164,13 @@ class _HUDState extends State<HUD> {
             child: Row(
               children: [
                 btnBuild("Solar", Building.solar,
-                    'assets/images/icons/icon_solar.png'),
+                    'assets/icons/icon_solar.png'),
                 btnBuild("Eólica", Building.eolica,
-                    'assets/images/icons/icon_wind.png'),
+                    'assets/icons/icon_wind.png'),
                 btnBuild("Eficiência", Building.eficiencia,
-                    'assets/images/icons/icon_efficiency.png'),
+                    'assets/icons/icon_efficiency.png'),
                 btnBuild("Saneamento", Building.saneamento,
-                    'assets/images/icons/icon_sanitation.png'),
+                    'assets/icons/icon_sanitation.png'),
                 const SizedBox(width: 8),
                 btnRemove(),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,4 @@ flutter:
   uses-material-design: true
 
   assets:
-    - assets/images/icons/icon_solar.png
-    - assets/images/icons/icon_wind.png
-    - assets/images/icons/icon_efficiency.png
-    - assets/images/icons/icon_sanitation.png
+    - assets/images/icons/


### PR DESCRIPTION
## Summary
- remove the duplicated `images/` prefix when loading Flame sprites
- reuse a shared map to load and cache icon sprites consistently

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dae4fef1988320928bee2d1568e95b